### PR TITLE
Assign correct addresses to spooled sourcedicts (distinguish simple vs. extended)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([libmarquise], [2.0.4], [engineering@anchor.net.au])
+AC_INIT([libmarquise], [3.0.0], [engineering@anchor.net.au])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([subdir-objects])
 LT_INIT

--- a/src/marquise.c
+++ b/src/marquise.c
@@ -445,7 +445,7 @@ char *serialise_marquise_source(marquise_source *source)
 	return serialised_dict;
 }
 
-int marquise_update_source(marquise_ctx *ctx, uint64_t address, marquise_source *source)
+int marquise_update_source(marquise_ctx *ctx, uint64_t address, marquise_source *source, point_type t)
 {
 	/* Appends the source_dict to the spool_path_contents file.
 
@@ -489,6 +489,15 @@ int marquise_update_source(marquise_ctx *ctx, uint64_t address, marquise_source 
 	if (buf == NULL) {
 		free(serialised_dict);
 		return -1;
+	}
+
+	/* Fix the address. Simple points have even addresses,
+	 * extended points have odd addresses.
+	 */
+	if (t == SIMPLE_POINT) {
+		address = address >> 1 << 1;
+	} else { /* t == EXTENDED_POINT */
+		address |= 1;
 	}
 
 	/* Build the buffer. */

--- a/src/marquise.h
+++ b/src/marquise.h
@@ -18,6 +18,10 @@
 #define SPOOL_CONTENTS 1
 typedef int spool_type;
 
+#define SIMPLE_POINT   0
+#define EXTENDED_POINT 1
+typedef int point_type;
+
 typedef struct {
 	char *marquise_namespace;
 	char *spool_path_points;
@@ -75,7 +79,7 @@ int marquise_send_extended(marquise_ctx *ctx, uint64_t address, uint64_t timesta
  * responsible for freeing the source (using `marquise_free_source`).
  * Returns zero on success, nonzero on failure.
  */
-int marquise_update_source(marquise_ctx *ctx, uint64_t address, marquise_source *source);
+int marquise_update_source(marquise_ctx *ctx, uint64_t address, marquise_source *source, point_type t);
 
 /* Clean up, flush, close and free. Zero on success, nonzero on
  * other things. */

--- a/src/tests/marquise_cache_test.c
+++ b/src/tests/marquise_cache_test.c
@@ -35,7 +35,7 @@ void test_cache() {
 	}
 
 	/* Dispatch sourcedict */
-	ret = marquise_update_source(ctx, TEST_ADDRESS, test_src);
+	ret = marquise_update_source(ctx, TEST_ADDRESS, test_src, EXTENDED_POINT);
 	if (ret != 0) {
 		perror("marquise_update_source failed (1st attempt)");
 		g_test_fail();
@@ -52,7 +52,7 @@ void test_cache() {
 	}
 
 	/* Dispatch again */
-	ret = marquise_update_source(ctx, TEST_ADDRESS, test_src);
+	ret = marquise_update_source(ctx, TEST_ADDRESS, test_src, EXTENDED_POINT);
 	if (ret != 0) {
 		perror("marquise_update_source failed (2nd attempt)");
 		g_test_fail();
@@ -75,7 +75,7 @@ void test_cache() {
 		return;
 	}
 	init_bytes_written = ctx->bytes_written_contents;
-	ret = marquise_update_source(ctx, TEST_ADDRESS, test_src2);
+	ret = marquise_update_source(ctx, TEST_ADDRESS, test_src2, EXTENDED_POINT);
 	if (ret != 0) {
 		perror("marquise_update_source failed (3rd attempt)");
 		g_test_fail();

--- a/src/tests/marquise_contents_write_readback_test.c
+++ b/src/tests/marquise_contents_write_readback_test.c
@@ -45,7 +45,7 @@ void test_contents_write_readback() {
 		return;
 	}
 
-	ret = marquise_update_source(ctx, TEST_ADDRESS, test_src);
+	ret = marquise_update_source(ctx, TEST_ADDRESS, test_src, EXTENDED_POINT);
 	if (ret != 0) {
 		perror("marquise_update_source failed");
 		g_test_fail();


### PR DESCRIPTION
**Caveat:** This PR should only be used if we determine that the correct behaviour is to distinguish between simple and extended sourcedicts (technically, sourcedicts for simple points and extended points). If so, this is a major breaking change with knock-on effects. If not, only a small change is needed, and this PR should be discarded (use the other one).

We've identified a problem with the way that sourcedicts are stored in
the vault. Normally, we generate an address and pass it along with
points and sourcedicts. For simple points, the address gets coerced to
an even number by setting the least significant bit to zero. Extended
points have their LSB set to one.

The same is not happening for sourcedicts. This means that they're being
stored at an unmangled address. As an example, we generate an address of
3. When simple points are sent, the address is coerced to 2. When the
sourcedict is sent the address will still be 3. Now when we retrieve
points from the vault, we find the sourcedict and expect to find data
points at address 3. There are none there.

This represents a big breaking change, it will affect pymarquise and
vaultaire-collector-pmacct.
