### PR TITLE
Assign correct addresses to spooled sourcedicts (squash simple and extended to same address)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([libmarquise], [2.0.4], [engineering@anchor.net.au])
+AC_INIT([libmarquise], [2.0.5], [engineering@anchor.net.au])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([subdir-objects])
 LT_INIT

--- a/src/marquise.c
+++ b/src/marquise.c
@@ -491,6 +491,9 @@ int marquise_update_source(marquise_ctx *ctx, uint64_t address, marquise_source 
 		return -1;
 	}
 
+	/* Fix the address, all sourcedicts have the LSB set to zero. */
+	address = address >> 1 << 1;
+
 	/* Build the buffer. */
 	U64TO8_LE(buf, address);
 	U64TO8_LE(buf + sizeof(address), serialised_dict_len);

--- a/src/tests/marquise_contents_write_readback_test.c
+++ b/src/tests/marquise_contents_write_readback_test.c
@@ -85,6 +85,7 @@ void test_contents_write_readback() {
 	// Now read it all back and test the serialisation
         // || address (64bit) || length (64bit) || serialised key-value pairs ||
 	uint64_t address;
+	uint64_t stored_address;
 	uint64_t length;
 	unsigned char header_buf[sizeof(address)+sizeof(length)];
 	char*    source_dict;
@@ -104,10 +105,12 @@ void test_contents_write_readback() {
 	}
 	LE8TOU64(address, header_buf);
 	LE8TOU64(length, (header_buf+sizeof(address)));
+	/* Sourcedicts are stored with the LSB set to zero. */
+	stored_address = address >> 1 << 1;
 
-	if (address != TEST_ADDRESS) {
+	if (address != stored_address) {
 		fclose(spool);
-		printf("Returned value of 'address' %lu doesn't match expected value of %lu\n", address, TEST_ADDRESS);
+		printf("Returned value of 'address' %lu doesn't match expected value of %lu\n", address, stored_address);
 		g_test_fail();
 		return;
 	}


### PR DESCRIPTION
**Caveat:** This PR should only be used if we determine that the correct behaviour is to follow the official Marquise client, and squash all sourcedict addresses to LSB=0. If so, this is a minor change with no knock-on effects. If not, a major change is needed, and this PR should be discarded (use the other one).

We've identified a problem with the way that sourcedicts are stored in
the vault. Normally, we generate an address and pass it along with
points and sourcedicts. For simple points, the address gets coerced to
an even number by setting the least significant bit to zero. Extended
points have their LSB set to one.

The same is not happening for sourcedicts. This means that it's possible
for data points and their associated sourcedict to be stored at
different addresses. This is bad, because we can enumerate the
sourcedicts, but won't necessarily find data points at the corresponding
address.

We've determined that the correct behaviour, at least if we follow the
"official" Marquise client, is to set the LSB of all sourcedicts to
zero.

This represents a minor change with no other repurcussions on other software.
