### PR TITLE
Fix memory leak in marquise_update_source

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([libmarquise], [2.0.5], [engineering@anchor.net.au])
+AC_INIT([libmarquise], [2.0.6], [engineering@anchor.net.au])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([subdir-objects])
 LT_INIT

--- a/src/marquise.c
+++ b/src/marquise.c
@@ -473,6 +473,7 @@ int marquise_update_source(marquise_ctx *ctx, uint64_t address, marquise_source 
 		g_tree_insert(ctx->sd_hashes, (gpointer)hash, (gpointer)dummy_value);
 	} else {
 		free(serialised_dict);
+		free(hash);
 		return 0;
 	}
 


### PR DESCRIPTION
Source dict hashes were being malloced but not freed if they already
existed in the tree.
