### PR TITLE
Make tests backwards compatible with glib < 2.30

### DIFF
--- a/src/marquise.h
+++ b/src/marquise.h
@@ -18,6 +18,11 @@
 
 #define SPOOL_POINTS   0
 #define SPOOL_CONTENTS 1
+
+#ifndef g_test_fail
+#define g_test_fail() g_assert(1==0)
+#endif
+
 typedef int spool_type;
 
 typedef struct {


### PR DESCRIPTION
g_test_fail() introduced in 2.30; debian squeeze runs 2.24

Define a always-fail g_assert pragma if g_test_fail is not available.

Pair programmed with @barneydesmond 
